### PR TITLE
Check TINYAPI_NODE for undefined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -57,7 +57,7 @@ export function ajax( url, body, method, dataType, contentType, additionalHeader
     .then( response => {
       if( response.ok ) {
         if( response.status != 204 ) {
-          if (TINYAPI_NODE) {
+          if (typeof TINYAPI_NODE !== 'undefined' && TINYAPI_NODE) {
             return response
           }
           return response.json()


### PR DESCRIPTION
Fix js-tinyapi failing in case of TINYAPI_NODE variable not being set (due to [this](https://stackoverflow.com/questions/9981104/why-does-an-undefined-variable-in-javascript-sometimes-evaluate-to-false-and-som))