### PR TITLE
If content type is multipart/form-data, don't set it

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -86,7 +86,9 @@ function makeHeaders(opts) {
   } = opts || {}
   let headers = {
     'X-Requested-With': 'XMLHttpRequest',
-    'Content-Type': contentType
+  }
+  if (contentType !== contentTypes.multiForm) {
+    headers['Content-Type'] = contentType
   }
   if (!isEmpty(ajaxSettings.csrf) && !(/^(GET|HEAD|OPTIONS\TRACE)$/i.test(method))) {
     headers['X-CSRFToken'] = ajaxSettings.csrf


### PR DESCRIPTION
This is to allow the content type header to be set automatically by the browser (including the right boundary etc.)