### PR TITLE
request returns response instead of response.data (breaking change)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -323,10 +323,9 @@ export default class Api {
       }
     }
 
-    // At this point the result will contain a data object and the
-    // response. Maintain backwards compatibility by only returning
-    // the data.
-    return obj.then(r => r.data)
+    // Return response.  Breaking change between version 0.2.6 and later versions, as this
+    // function has previously been returning response.data
+    return obj
   }
 }
 


### PR DESCRIPTION
As of version 0.2.0 the return value has been response.data instead of a whole response object.  This has probably been done in error, as the comments indicate the intention of backwards compatibility and it looks like the `obj` was assumed to be a different shape.