### PR TITLE
Do not cache the CSRF token ever

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-tinyapi",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "A simple and lightweight API helper.",
   "repository": {
     "type": "git",

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,6 @@ function isEmpty(value) {
  * a cookie called "csrftoken").
  */
 let ajaxSettings = {
-  csrf: Cookies ? Cookies.get('csrftoken') : undefined,
   bearer: null
 }
 
@@ -90,8 +89,9 @@ function makeHeaders(opts) {
   if (contentType !== contentTypes.multiForm) {
     headers['Content-Type'] = contentType
   }
-  if (!isEmpty(ajaxSettings.csrf) && !(/^(GET|HEAD|OPTIONS\TRACE)$/i.test(method))) {
-    headers['X-CSRFToken'] = ajaxSettings.csrf
+  const csrf = Cookies ? Cookies.get('csrftoken') : undefined
+  if (!isEmpty(csrf) && !(/^(GET|HEAD|OPTIONS\TRACE)$/i.test(method))) {
+    headers['X-CSRFToken'] = csrf
   }
   if (!bearer) {
     bearer = ajaxSettings.bearer


### PR DESCRIPTION
csrftoken should never be cached as whenever a user logs in again they will be regenerated. We have recently converted to SPA which is exposes this to be a problem.

1. User goes to log in. js-tinyapi caches the csrftoken from the backend.
2. User logins in. At this point the csrftoken changes and js-tinyapi is left holding a stale token.
3. Henceforth every POST / PATCH operation is borked.

Note. The tests appear to be busted but this repo looks stale so I'm not sure if they ever worked?